### PR TITLE
Docker container launch locally

### DIFF
--- a/pages/guide/02-start.md
+++ b/pages/guide/02-start.md
@@ -19,11 +19,15 @@ Once your machine has all met the prerequisites, run the following steps to boot
 git clone https://github.com/yahoo/navi.git 
 ```
 
-### 2. Boot the web service
+### 2.1 Boot the web service
 
 ```shell
 cd navi/packages/webserivce                 
 ./gradlew bootRun                           
+```
+### 2.2 Docker container launch with demo
+```
+docker run docker.io/verizonmedia/yavin:demo_local
 ```
 
 (To stop the server at any time, type Ctrl-C in your terminal.)

--- a/pages/guide/02-start.md
+++ b/pages/guide/02-start.md
@@ -19,14 +19,15 @@ Once your machine has all met the prerequisites, run the following steps to boot
 git clone https://github.com/yahoo/navi.git 
 ```
 
-### 2.1 Boot the web service
+### 2.1 (Option 1): Run Jar Oocally
 
 ```shell
 cd navi/packages/webserivce                 
 ./gradlew bootRun                           
 ```
-### 2.2 Docker container launch with demo
-```
+### 2.2 (Option 2): Launch Demo App in Docker Container
+
+```shell
 docker run docker.io/verizonmedia/yavin:demo_local
 ```
 


### PR DESCRIPTION
yavin demo app image is published on hub.docker.com
assuming docker is installed on local machine a user can run this 
which will directly launch the demo app. No build or anything required.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
