### PR TITLE
Soften table lines with table style reset

### DIFF
--- a/_sass/denali.scss
+++ b/_sass/denali.scss
@@ -299,19 +299,19 @@ $table-border-radius: $border-radius-md;
 $table-row-default-height: 48px;
 $table-row-condensed-height: 40px;
 $table-row-expanded-height: 56px;
-$table-row-border-bottom: solid 1px $color-grey-800;
+$table-row-border-bottom: solid 1px $color-grey-400;
 $table-row-padding: 0px 10px;
 $table-header-text-color: $color-grey-800;
 $table-header-text-size: 1.2rem;
 $table-header-text-transform: uppercase;
 $table-header-text-weight: normal;
 $table-header-padding: 10px;
-$table-header-border-bottom: solid 2px $color-grey-800;
+$table-header-border-bottom: solid 2px $color-grey-400;
 $table-header-sort-text-weight: bold;
-$table-footer-bg-color: $color-grey-800;
-$table-striped-row-bg-color: $color-grey-800;
+$table-footer-bg-color: $color-grey-400;
+$table-striped-row-bg-color: $color-grey-200;
 $table-cards-spacing: 0px 10px;
-$table-cards-border: solid 1px $color-grey-800;
+$table-cards-border: solid 1px $color-grey-400;
 
 // Tabs
 // $tabs-primary-bg-color: #1E242A;


### PR DESCRIPTION
Resetting table to default denali style. This will soften the hard lines in tables.

Before:
<img width="859" alt="Screen Shot 2020-12-14 at 8 36 29 PM" src="https://user-images.githubusercontent.com/92278/102161056-3b676300-3e4c-11eb-81fb-a1987a9f018f.png">

After:
<img width="867" alt="Screen Shot 2020-12-14 at 8 36 14 PM" src="https://user-images.githubusercontent.com/92278/102161080-45896180-3e4c-11eb-8cec-71903c5f5a36.png">


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
