### PR TITLE
Update copyright from Verizon Media to Yahoo

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -13,7 +13,7 @@
         </div>{% endfor %}
       </div>
       <div class="xs-col-1-1 sm-col-1-1 md-col-1-2 lg-col-1-2 xl-col-1-2 flex flex-column align-self-center align-items-flex-end">
-        <h6>Copyright Verizon Media</h6>
+        <h6>Copyright Yahoo</h6>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Description
Updated  copyright from Verizon Media to Yahoo

## Screenshots
<img width="869" alt="Screen Shot 2022-04-01 at 2 43 27 PM" src="https://user-images.githubusercontent.com/5622615/161331257-22291d0d-848f-4e34-a675-c8ab811c179f.png">

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
